### PR TITLE
Fix typo in basedir form label

### DIFF
--- a/library/Fileshipper/ProvidedHook/Director/ImportSource.php
+++ b/library/Fileshipper/ProvidedHook/Director/ImportSource.php
@@ -78,7 +78,7 @@ class ImportSource extends ImportSourceHook
         $format = $form->getSentOrObjectSetting('file_format');
 
         $form->addElement('select', 'basedir', array(
-            'label'        => $form->translate('Base directoy'),
+            'label'        => $form->translate('Base directory'),
             'description'  => sprintf(
                 $form->translate(
                     'This import rule will only work with files relative to this'


### PR DESCRIPTION
Simple typo fix in the form label for base directory