### PR TITLE
Fix english in GUI labels

### DIFF
--- a/library/Fileshipper/ProvidedHook/Director/ImportSource.php
+++ b/library/Fileshipper/ProvidedHook/Director/ImportSource.php
@@ -63,9 +63,9 @@ class ImportSource extends ImportSourceHook
             'label'        => $form->translate('File format'),
             'description'  => $form->translate(
                 'Available file formats, usually CSV, JSON, YAML and XML. Whether'
-                . ' all of those are available eventually depends on various'
-                . ' libraries installed on your system. Please have a look at'
-                . ' the documentation in case your list is not complete.'
+                . ' these are currently available depends on various'
+                . ' libraries installed on your system.  Please see'
+                . ' the documentation if you do not see the complete list.'
             ),
             'required'     => true,
             'class'        => 'autosubmit',
@@ -137,8 +137,8 @@ class ImportSource extends ImportSourceHook
         $form->addElement('text', 'csv_delimiter', array(
             'label'       => $form->translate('Field delimiter'),
             'description' => $form->translate(
-                'This sets the field delimiter. One character only, defaults'
-                . ' to comma: ,'
+                'This sets the field delimiter.  It must be exactly one'
+                . '  character, defaults to comma: ,'
             ),
             'value'       => ',',
             'required'    => true,
@@ -147,8 +147,8 @@ class ImportSource extends ImportSourceHook
         $form->addElement('text', 'csv_enclosure', array(
             'label'       => $form->translate('Value enclosure'),
             'description' => $form->translate(
-                'This sets the field enclosure character. One character only,'
-                . ' defaults to double quote: "'
+                'This sets the field enclosure character. It must be exactly'
+                . ' one character,defaults to double quote: "'
             ),
             'value'       => '"',
             'required'    => true,

--- a/library/Fileshipper/Xlsx/Workbook.php
+++ b/library/Fileshipper/Xlsx/Workbook.php
@@ -238,7 +238,7 @@ class Workbook
         if (is_numeric($sheet)) {
             $sheet = $this->getSheetNameById($sheet);
         } elseif (!is_string($sheet)) {
-            throw new RuntimeException("Sheet must be a string or a sheet Id");
+            throw new RuntimeException("Sheet must be a string or a sheet ID");
         }
         if (!array_key_exists($sheet, $this->sheets)) {
             $this->sheets[$sheet] = new Worksheet($this->getSheetXML($sheet), $sheet, $this);

--- a/library/Fileshipper/Xlsx/Worksheet.php
+++ b/library/Fileshipper/Xlsx/Worksheet.php
@@ -130,7 +130,7 @@ class Worksheet
                         $rows[$curR][$col] = $rows[$cell[0]][$cell[1]];
                     } else {
                         throw new RuntimeException(sprintf(
-                            '%s should merge into %s, but %s has a value: %s',
+                            '%s should merge into %s, but %s already has a value: %s',
                             $this->makeCellName($cell[0], $cell[1]),
                             $this->makeCellName($curR, $col),
                             $this->makeCellName($curR, $col),


### PR DESCRIPTION
### Current Behavior
There is written the word "directoy" in modules/fileshipper/library/Fileshipper/ProvidedHook/Director/ImportSource.php and
' defaults to double quote: "' in the same file, which is not true as the field requires a character

![screenshot from 2019-02-07 16-58-21](https://user-images.githubusercontent.com/47357312/52424099-9a921900-2af9-11e9-81e3-35155db599a4.png)

### How to reproduce
* Director
* Import data sources
* Add
* under "source type" select Fileshipper
* look at the additional options that pop up

### My Environment
* Director Version: 1.5.1
* Icinga 2 version: 2.10.1-1
* Operating System and version: Centos 7
* PHP versions: rh-php71-php-fpm-7.1.8

### Comment

This pull request refers to the pull request (https://github.com/Icinga/icingaweb2-module-fileshipper/pull/28) but with suggestions from @Thomas-Gelf 