### PR TITLE
Refactor listColumns() method to remove deprecated current() function

### DIFF
--- a/library/Fileshipper/ProvidedHook/Director/ImportSource.php
+++ b/library/Fileshipper/ProvidedHook/Director/ImportSource.php
@@ -49,7 +49,13 @@ class ImportSource extends ImportSourceHook
      */
     public function listColumns()
     {
-        return array_keys((array) current($this->fetchData()));
+        $rows = $this->fetchData();
+
+        if (empty($rows)) {
+            return [];
+        }
+
+        return array_keys((array) $rows[0]);
     }
 
     /**

--- a/test/php/library/Fileshipper/ProvidedHook/Director/ImportSourceTest.php
+++ b/test/php/library/Fileshipper/ProvidedHook/Director/ImportSourceTest.php
@@ -95,4 +95,17 @@ final class ImportSourceTest extends TestCase
         // Requires php-xml
         $this->assertEquals($is->fetchData(), $this->actualData);
     }
+
+    public function testlistColumns(): void
+    {
+        $is = new ImportSource();
+
+        $is->setSettings([
+            'basedir' => getcwd() . '/test/config',
+            'file_name' => 'test.json',
+            'file_format' => 'json']
+        );
+
+        $this->assertEquals($is->listColumns(), [0 => 'host', 1 => 'address']);
+    }
 }


### PR DESCRIPTION
 - Since PHP 8.1 calling current() function on objects is deprecated

https://www.php.net/manual/en/function.current.php