### PR TITLE
Support PHP 8.5

### DIFF
--- a/library/Fileshipper/ProvidedHook/Director/ImportSource.php
+++ b/library/Fileshipper/ProvidedHook/Director/ImportSource.php
@@ -381,9 +381,9 @@ class ImportSource extends ImportSourceHook
         $enclosure = $this->getSetting('csv_enclosure');
         // $escape    = $this->getSetting('csv_escape');
 
-        $headers = fgetcsv($fh, 0, $delimiter, $enclosure/*, $escape*/);
+        $headers = fgetcsv($fh, 0, $delimiter, $enclosure, '\\');
         $row = 1;
-        while ($line = fgetcsv($fh, 0, $delimiter, $enclosure/*, $escape*/)) {
+        while ($line = fgetcsv($fh, 0, $delimiter, $enclosure, '\\')) {
             if (empty($line)) {
                 continue;
             }

--- a/library/Fileshipper/Xlsx/Worksheet.php
+++ b/library/Fileshipper/Xlsx/Worksheet.php
@@ -234,8 +234,6 @@ class Worksheet
                         $value = (int) $value;
                     } elseif ($value == (float) $value) {
                         $value = (float) $value;
-                    } elseif ($value == (double) $value) {
-                        $value = (double) $value;
                     }
                 }
         }


### PR DESCRIPTION
- Explicitly specify the `$escape` argument when calling `fgetcsv()`, since relying on its default value has been deprecated as of PHP 8.4.

- Remove redundant branch using a `(double)` cast, which is deprecated as of PHP 8.5 and safe to delete in this context anyway.

resolves #45 